### PR TITLE
chore: refatorados os readmes principais do projeto (Pt-Br e En-US)

### DIFF
--- a/README-en-US.md
+++ b/README-en-US.md
@@ -8,7 +8,33 @@
 
 # Aratinga - CMS
 
-Content Management System in Python / Django and Wagtail
+Aratinga is a web Content Management System built with Python, Django, and Wagtail.
 
-The professional WordPress alternative for building marketing websites with
-Wagtail.
+A professional alternative for building and marketing websites with Wagtail.
+
+### Run
+``` CLI
+aratinga start mysite
+```
+
+### Messages
+
+###### Creating an Aratinga project called mysite
+
+###### Success! mysite has been created
+
+### Next steps
+``` CLI
+cd mysite/
+```
+``` CLI
+python manage.py migrate
+```
+``` CLI
+python manage.py createsuperuser
+```
+``` CLI
+python manage.py runserver
+```
+
+### Go to: 'http://localhost:8000/admin/' and start editing!

--- a/README.md
+++ b/README.md
@@ -12,15 +12,28 @@ Aratinga é um sistema de gerenciamento de Conteúdo para internet (_Content Man
 
 Uma alternativa profissional para criação e marketing de websites com Wagtail.
 
-
+### Execute:
+``` CLI
 aratinga start mysite
+```
+### Mensagens:
 
-Creating a Aratinga project called mysite
-Success! mysite has been created
+###### Creating a Aratinga project called mysite
 
-        Next steps:
-            1. cd mysite/
-            2. python manage.py migrate
-            3. python manage.py createsuperuser
-            4. python manage.py runserver
-            5. Go to http://localhost:8000/admin/ and start editing!
+###### Success! mysite has been created
+
+### Próximos passos:
+``` CLI
+cd mysite/
+```
+``` CLI
+python manage.py migrate
+```
+``` CLI
+python manage.py createsuperuser
+```
+``` CLI
+python manage.py runserver
+```
+
+### Vá para: 'http://localhost:8000/admin/' e comece a editar!


### PR DESCRIPTION
chore: refatorados os readmes principais do projeto para ter trechos de código declarados "```CLI[...]```" para facilitar execução de comandos, além de refletir 100% da estrutura do README.md para README-en-US.md com a diferença de idioma apenas.